### PR TITLE
scoretypes: improve restricted feedback behaviour

### DIFF
--- a/cms/grading/scoretypes/abc.py
+++ b/cms/grading/scoretypes/abc.py
@@ -392,7 +392,12 @@ class ScoreTypeGroup(ScoreTypeAlone):
 
             testcases = []
             public_testcases = []
+            # In restricted feedback:
+            # - show until the first incorrect testcase (if there's any)
+            # - otherwise, show until the first partial testcase
             previous_tc_all_correct = True
+            previous_tc_all_positive = True
+            tc_may_show_later = []
             for tc_idx in target:
                 tc_outcome = self.get_public_outcome(
                     float(evaluations[tc_idx].outcome), parameter)
@@ -404,6 +409,8 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     "time": evaluations[tc_idx].execution_time,
                     "memory": evaluations[tc_idx].execution_memory,
                     "show_in_restricted_feedback": previous_tc_all_correct})
+                if previous_tc_all_positive and not previous_tc_all_correct:
+                    tc_may_show_later.append(testcases[-1])
                 if self.public_testcases[tc_idx]:
                     public_testcases.append(testcases[-1])
                     # Only block restricted feedback if this is the first
@@ -411,6 +418,10 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     # leaking info on private testcases.
                     if tc_outcome != "Correct":
                         previous_tc_all_correct = False
+                        if previous_tc_all_positive and tc_outcome != "Partially correct":
+                            previous_tc_all_positive = False
+                            for hidden_tc in tc_may_show_later:
+                                hidden_tc["show_in_restricted_feedback"] = True
                 else:
                     public_testcases.append({"idx": tc_idx})
 


### PR DESCRIPTION
Issue with existing implementation: if there is a partial testcase first and an incorrect testcase later, the incorrect one will be hidden.
A. This is confusing, e.g.,
![kép](https://github.com/ioi-2023/cms/assets/37755878/bd4e7fd0-ca13-4ee3-bc52-a0a9a5a7de72)
![kép](https://github.com/ioi-2023/cms/assets/37755878/cecbe3e8-24f5-455d-be39-ffaddb2e498d)
B. This is against the purpose of giving restricted feedback, as contestants won't learn the details of an incorrect testcase (WA or TL or etc)
Proposed solution: if there's at least one incorrect testcase, show feedback until the first of those; otherwise show until the first not fully correct testcase.